### PR TITLE
ci: guard release tag crate version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: 'recursive'
     - name: Check release version
       if: startsWith(github.ref, 'refs/tags/')
-      run: scripts/check-release-version.sh
+      run: bash scripts/check-release-version.sh
     - name: Generate Cargo.toml.cache (Ignore version=)
       run: |
         sed '/^version = /d' Cargo.toml >> Cargo.toml.cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,9 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
+    - name: Check release version
+      if: startsWith(github.ref, 'refs/tags/')
+      run: scripts/check-release-version.sh
     - name: Generate Cargo.toml.cache (Ignore version=)
       run: |
         sed '/^version = /d' Cargo.toml >> Cargo.toml.cache

--- a/release.sh
+++ b/release.sh
@@ -19,6 +19,7 @@ prev_version=$(get_full_version "$prev_tag")
 echo "Releasing version: $full_version (previous: $prev_version)"
 # cargo install cargo-jump; echo "See https://github.com/taoky/cargo-jump"
 cargo jump --old-tag="$prev_tag" "$full_version"
+./scripts/check-release-version.sh "refs/tags/$version"
 git commit -a -m "Bump version to $full_version"
 git tag "$version" -m "$msg"
 echo "Release prepared. Run 'git push' and 'git push --tags' to publish the release."

--- a/scripts/check-release-version.sh
+++ b/scripts/check-release-version.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+ref="${1:-${GITHUB_REF:-}}"
+manifest="${TSUMUGU_CLI_MANIFEST:-tsumugu-cli/Cargo.toml}"
+
+if [[ -z "$ref" ]]; then
+    echo "No git ref provided; skipping release version check."
+    exit 0
+fi
+
+if [[ "$ref" != refs/tags/* ]]; then
+    echo "Ref $ref is not a tag; skipping release version check."
+    exit 0
+fi
+
+tag="${ref#refs/tags/}"
+
+if [[ "$tag" == *.* ]]; then
+    expected_version="0.$tag"
+else
+    expected_version="0.$tag.0"
+fi
+
+actual_version=$(
+    awk '
+        $0 == "[package]" { in_package = 1; next }
+        /^\[/ && in_package { exit }
+        in_package && $1 == "version" && $2 == "=" {
+            gsub(/"/, "", $3)
+            print $3
+            exit
+        }
+    ' "$manifest"
+)
+
+if [[ -z "$actual_version" ]]; then
+    echo "Could not read package.version from $manifest" >&2
+    exit 1
+fi
+
+if [[ "$actual_version" != "$expected_version" ]]; then
+    echo "Release tag $tag expects crate version $expected_version, but $manifest has $actual_version." >&2
+    echo "Run release.sh or update the crate version before pushing the tag." >&2
+    exit 1
+fi
+
+echo "Release tag $tag matches crate version $actual_version."

--- a/tests/check-release-version.sh
+++ b/tests/check-release-version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if output=$(bash scripts/check-release-version.sh refs/tags/20260424 2>&1); then
+    status=0
+else
+    status=$?
+fi
+if [[ "$status" -eq 0 ]]; then
+    echo "expected mismatched release tag to fail" >&2
+    exit 1
+fi
+if [[ "$output" != *"0.20260424.0"* || "$output" != *"0.20260323.1"* ]]; then
+    echo "mismatched release tag output did not mention expected and actual versions" >&2
+    echo "$output" >&2
+    exit 1
+fi
+
+bash scripts/check-release-version.sh refs/tags/20260323.1 >/dev/null
+GITHUB_REF=refs/heads/pudding bash scripts/check-release-version.sh >/dev/null
+
+echo "release version checks passed"

--- a/tests/check-release-version.sh
+++ b/tests/check-release-version.sh
@@ -3,7 +3,17 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if output=$(bash scripts/check-release-version.sh refs/tags/20260424 2>&1); then
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+manifest="$tmpdir/Cargo.toml"
+cat >"$manifest" <<'EOF'
+[package]
+name = "tsumugu"
+version = "0.20260323.1"
+EOF
+
+if output=$(TSUMUGU_CLI_MANIFEST="$manifest" bash scripts/check-release-version.sh refs/tags/20260424 2>&1); then
     status=0
 else
     status=$?
@@ -18,7 +28,7 @@ if [[ "$output" != *"0.20260424.0"* || "$output" != *"0.20260323.1"* ]]; then
     exit 1
 fi
 
-bash scripts/check-release-version.sh refs/tags/20260323.1 >/dev/null
+TSUMUGU_CLI_MANIFEST="$manifest" bash scripts/check-release-version.sh refs/tags/20260323.1 >/dev/null
 GITHUB_REF=refs/heads/pudding bash scripts/check-release-version.sh >/dev/null
 
 echo "release version checks passed"


### PR DESCRIPTION
## Summary
- add a release-version guard that maps tag names to crate versions (`20260424` -> `0.20260424.0`, `20260323.1` -> `0.20260323.1`)
- fail tag workflows before creating GitHub releases or publishing crates when `tsumugu-cli/Cargo.toml` has not been bumped
- run the same guard from `release.sh` after `cargo jump` so local releases catch the mismatch earlier

## Motivation
`tunathu/tsumugu` installs `tsumugu` from crates.io, so a GitHub release/tag without a matching crate version leaves downstream Docker images on the previous published crate. This guard prevents tag releases like `20260424` from succeeding while `tsumugu-cli` still declares `0.20260323.1`.

## Testing
- `bash scripts/check-release-version.sh refs/tags/20260424` fails and reports expected `0.20260424.0` vs actual `0.20260323.1`
- `bash scripts/check-release-version.sh refs/tags/20260323.1` passes
- `GITHUB_REF=refs/heads/pudding bash scripts/check-release-version.sh` skips non-tag refs
- `bash tests/check-release-version.sh`
- `git diff --check`